### PR TITLE
Bumping versions and brooming for 25-26

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,11 @@
 This GitHub repository contains example code to help you learn how to use Cucumber for testing.
 
 **Key Features**:
-- Cucumber 7 and JUnit 5
-- Compatible with Maven
-- Requires JDK 21
-- Mockito 4.8 (_Non utilisé dans cette version pour l'instant_)
+- Cucumber 7 and JUnit 5 (last stable and compatible versions as of August 2025)
+- Requires JDK 21 (not 25) and Maven 3.9
+- Mockito 5 (last stable version as of August 2025)
 - Gherkin and stepDefs in both French (FR) and English (EN), including integration of _Examples_
 - GitHub Actions (Check the .github/workflows) for straightforward Maven compilation and testing.
-
 
 ## Execution of tests
 
@@ -20,24 +18,21 @@ expected result:
 ```
 ...... (output shortened)
 
-[INFO] Results:
 [INFO] 
 [INFO] Results:
 [INFO] 
-[INFO] Tests run: 46, Failures: 0, Errors: 0, Skipped: 0
+[INFO] Tests run: 31, Failures: 0, Errors: 0, Skipped: 0
 [INFO] 
 [INFO] ------------------------------------------------------------------------
 [INFO] BUILD SUCCESS
 [INFO] ------------------------------------------------------------------------
-[INFO] Total time:  1.053 s
-[INFO] Finished at: 2024-09-05T19:37:26+02:00
-[INFO] ------------------------------------------------------------------------
-```
+[INFO] Total time:  2.871 s
+[INFO] Finished at: 2025-09-08T11:51:30+02:00
+[INFO] ------------------------------------------------------------------------```
 
 ## Organisation of the code
 
-:warning: **Please use the** **pom.xml** file provided to establish the link between JUnit 5 and Cucumber.
-
+:warning: **Please use the** **pom.xml** file provided to establish a working link between JUnit 5 and Cucumber (generative AIs tend to provide outdated or incompatible dependencies).
 
 :arrow_forward: **Features:** 
 The feature description files (Gherkin files) are accessible under [test/resources/features](./src/test/resources/features)
@@ -46,7 +41,8 @@ The feature description files (Gherkin files) are accessible under [test/resourc
 
 ## Enabling Cucumber Support in IntelliJ IDEA
 
-https://www.jetbrains.com/help/idea/enabling-cucumber-support-in-project.html
+The support has to be activated in IntelliJ IDEA. To do this, install the Cucumber for Java plugin: https://plugins.jetbrains.com/plugin/7212-cucumber-for-java
+Still, as Cucumber has made many changes in recent versions, the support is not perfect.
 
 ## Warning
 1. Attention: if the classes defining the steps are not public, they are not accessible during execution.
@@ -64,35 +60,3 @@ It must be noted that *surefire* will, by default, find tests with the following
 * `"**/*Test.java"` - includes all of its subdirectories and all Java filenames that end with "Test".
 * `"**/*Tests.java"` - includes all of its subdirectories and all Java filenames that end with "Tests".
 * `"**/*TestCase.java"` - includes all of its subdirectories and all Java filenames that end with "TestCase".`
-
-
-## Tests
-
-Seuls des tests unitaires, d'intégration et de validation vous sont demandés dans la première partie de ce module.
-
-### Unit tests
-Les tests unitaires sont des tests qui vérifient le bon fonctionnement d'une unité de code (une méthode, une classe, etc.) de manière isolée.
-
-[EtudiantTest.java](src%2Ftest%2Fjava%2Ffr%2Funice%2Fpolytech%2Fbiblio%2Fentities%2FEtudiantTest.java),
- [LivreTest.java](src%2Ftest%2Fjava%2Ffr%2Funice%2Fpolytech%2Fbiblio%2Fentities%2FLivreTest.java),  
-[JaxsonUtilsTest.java](src%2Ftest%2Fjava%2Ffr%2Funice%2Fpolytech%2Fbiblio%2Fserver%2FJaxsonUtilsTest.java)    sont des exemples de tests unitaires.
-
-### Integration tests
-Les tests d'intégration sont des tests qui vérifient le bon fonctionnement de plusieurs unités de code ensemble.
-
-[IntegrationOfScolarityTest.java](src%2Ftest%2Fjava%2Ffr%2Funice%2Fpolytech%2Fbiblio%2Fserver%2FIntegrationOfScolarityTest.java) est un exemple de tests d'intégration où le StudentRegistry est mocké.
-
-### Validation tests
-Les tests de validation sont des tests qui vérifient que le code respecte certaines règles de validation.
-Sous [back](src%2Ftest%2Fresources%2Ffeatures%2Fbiblio%2Fback): les scénarios visent à tester la partie arrière, métier de l'application.
-
-### End-to-end tests
-Les tests end-to-end sont des tests qui vérifient le bon fonctionnement de l'application dans son ensemble.
-Ces tests s'expriment en considérant l'application comme une boîte noire, c'est-à-dire que nous ne nous intéressons pas à la manière dont l'application est implémentée, mais seulement à son comportement.
-
-[APITesting.feature](src%2Ftest%2Fresources%2Ffeatures%2Fbiblio%2FAPITesting.feature) correspond à des tests end-to-end.
-
-### API tests
-Les tests API sont des tests qui vérifient le bon fonctionnement de l'API de l'application.
-[KarateLikeAPITesting.feature](src%2Ftest%2Fresources%2Ffeatures%2Fbiblio%2FKarateLikeAPITesting.feature) explicite des tests API.
-Ils s'inspirent de Karate, un outil de test d'API qui permet de tester des API REST.

--- a/README.md
+++ b/README.md
@@ -18,17 +18,19 @@ expected result:
 ```
 ...... (output shortened)
 
+[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.179 s -- in fr.unice.polytech.biblio.RunCucumberTest
 [INFO] 
 [INFO] Results:
 [INFO] 
-[INFO] Tests run: 31, Failures: 0, Errors: 0, Skipped: 0
+[INFO] Tests run: 52, Failures: 0, Errors: 0, Skipped: 0
 [INFO] 
 [INFO] ------------------------------------------------------------------------
 [INFO] BUILD SUCCESS
 [INFO] ------------------------------------------------------------------------
-[INFO] Total time:  2.871 s
-[INFO] Finished at: 2025-09-08T11:51:30+02:00
-[INFO] ------------------------------------------------------------------------```
+[INFO] Total time:  2.169 s
+[INFO] Finished at: 2025-09-08T14:24:11+02:00
+[INFO] ------------------------------------------------------------------------
+```
 
 ## Organisation of the code
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,15 +11,19 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
-        <junit.jupiter.version>5.9.1</junit.jupiter.version>
-        <cucumber.version>7.18.1</cucumber.version>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
+        <junit.jupiter.version>5.13.4</junit.jupiter.version>
+        <cucumber.version>7.28.1</cucumber.version>
+        <mockito.version>5.19.0</mockito.version>
+        <jackson.version>2.20.0</jackson.version>
     </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.9.3</version>
+                <version>${junit.jupiter.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -30,27 +34,31 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
         <dependency>
-            <groupId>io.cucumber</groupId>
-            <artifactId>cucumber-java</artifactId>
+            <groupId>org.picocontainer</groupId>
+            <artifactId>picocontainer</artifactId>
+            <version>2.15.2</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.cucumber</groupId>
-            <artifactId>cucumber-junit-platform-engine</artifactId>
+            <artifactId>cucumber-java</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency> <!-- Junit 5 vintage to JUnit 4 necessary for Cucumber 4.X + Junit 5.X -->
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit.jupiter.version}</version>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit-platform-engine</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -61,48 +69,20 @@
         </dependency>
 
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <!-- 23-not needed? <version>5.8.2</version> -->
-            <scope>test</scope>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/io.cucumber/cucumber-picocontainer -->
-        <!-- <dependency>
-            <groupId>io.cucumber</groupId>
-            <artifactId>cucumber-picocontainer</artifactId>
-            <version>7.8.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.picocontainer</groupId>
-            <artifactId>picocontainer</artifactId>
-            <version>2.15</version>
-            <scope>compile</scope>
-        </dependency>
-        -->
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.8.1</version>
-        </dependency>
-        <!--
-        <dependency>
-            <groupId>info.picocli</groupId>
-            <artifactId>picocli</artifactId>
-            <version>4.7.0</version>
-        </dependency>
-        -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.17.2</version>
+            <version>${mockito.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.17.2</version>
+            <version>${jackson.version}</version>
         </dependency>
 
     </dependencies>
@@ -112,28 +92,24 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
-                <configuration>
-                    <encoding>UTF-8</encoding>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                </configuration>
+                <version>3.14.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.5.3</version>
                 <configuration>
                     <properties>
                         <!-- Work around. Surefire does not include enough
                              information to disambiguate between different
                              examples and scenarios. -->
                         <configurationParameters>
-                            cucumber.junit-platform.naming-strategy=long
+                            cucumber.junit-platform.naming-strategy=surefire
                         </configurationParameters>
                     </properties>
                 </configuration>
             </plugin>
         </plugins>
     </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
+                <version>3.5.2</version> <!-- do not use 3.5.3, open bug on counting cucumber tests -->
                 <configuration>
                     <properties>
                         <!-- Work around. Surefire does not include enough

--- a/src/test/java/fr/unice/polytech/biblio/RunCucumberTest.java
+++ b/src/test/java/fr/unice/polytech/biblio/RunCucumberTest.java
@@ -5,9 +5,8 @@ import org.junit.platform.suite.api.IncludeEngines;
 import org.junit.platform.suite.api.SelectClasspathResource;
 import org.junit.platform.suite.api.Suite;
 
-import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
-import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
-
+import static io.cucumber.core.options.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.core.options.Constants.PLUGIN_PROPERTY_NAME;
 
 @Suite
 @IncludeEngines("cucumber")
@@ -21,5 +20,5 @@ import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
 
 public class RunCucumberTest {
     // will run all features found on the classpath
-    // in the same package as this class
+    // in the same package as this class (can be changed with @SelectPackages)
 }

--- a/src/test/java/fr/unice/polytech/biblio/RunCucumberTest.java
+++ b/src/test/java/fr/unice/polytech/biblio/RunCucumberTest.java
@@ -1,9 +1,6 @@
 package fr.unice.polytech.biblio;
 
-import org.junit.platform.suite.api.ConfigurationParameter;
-import org.junit.platform.suite.api.IncludeEngines;
-import org.junit.platform.suite.api.SelectClasspathResource;
-import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.*;
 
 import static io.cucumber.core.options.Constants.GLUE_PROPERTY_NAME;
 import static io.cucumber.core.options.Constants.PLUGIN_PROPERTY_NAME;
@@ -11,14 +8,10 @@ import static io.cucumber.core.options.Constants.PLUGIN_PROPERTY_NAME;
 @Suite
 @IncludeEngines("cucumber")
 
-//Specifies the location of the feature files. The feature files are stored in the "features/biblio" directory within the classpath.
-@SelectClasspathResource("features/biblio")
-
+@SelectPackages("features.biblio")
 @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty")
-//Specifies the package where the step definitions are located.
-@ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "fr.unice.polytech.biblio")
+@ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "fr.unice.polytech.biblio.stepDefs")
 
 public class RunCucumberTest {
-    // will run all features found on the classpath
-    // in the same package as this class (can be changed with @SelectPackages)
+    // will run all features found on the configuration
 }

--- a/src/test/java/fr/unice/polytech/biblio/stepDefs/backend/BibliothequeStepdefs.java
+++ b/src/test/java/fr/unice/polytech/biblio/stepDefs/backend/BibliothequeStepdefs.java
@@ -14,8 +14,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BibliothequeStepdefs {
 

--- a/src/test/java/fr/unice/polytech/biblio/stepDefs/backend/EmpruntLivreStepdefs.java
+++ b/src/test/java/fr/unice/polytech/biblio/stepDefs/backend/EmpruntLivreStepdefs.java
@@ -8,8 +8,8 @@ import io.cucumber.java.fr.*;
 
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**


### PR DESCRIPTION
The diff below is quite explicit:
- bumped the versions
- broomed the pom.xml to get rid of JUnit vintage (and replaced the code using old JUnit assert API)
- downgrade maven compiler to avoid a bug
- updated the configuration in cucumber class
- synced the README